### PR TITLE
feat:Info metric

### DIFF
--- a/Prometheus/DotNetRuntimeInfos.cs
+++ b/Prometheus/DotNetRuntimeInfos.cs
@@ -1,0 +1,41 @@
+﻿using System.Runtime.InteropServices;
+
+namespace Prometheus
+{
+    public static class DotNetRuntimeInfos
+    {
+        /// <summary>
+        /// Registers the .NET runtime infos in the default registry.
+        /// </summary>
+        internal static void RegisterDefault()
+        {
+            Register(Metrics.DefaultFactory);
+        }
+
+        /// <summary>
+        /// Registers the .NET runtime infos in the specified registry.
+        /// </summary>
+        /// <param name="registry"></param>
+        public static void Register(CollectorRegistry registry)
+        {
+            Register(Metrics.WithCustomRegistry(registry));
+        }
+
+        /// <summary>
+        /// Registers the .NET runtime infos in the specified factory.
+        /// </summary>
+        /// <param name="factory"></param>
+        public static void Register(MetricFactory factory)
+        {
+            factory.CreateInfo("dotnet_info", ".NET runtime", new[] { "version", "framework", "runtime" })
+                .WithLabels(Environment.Version.ToString(), RuntimeInformation.FrameworkDescription, RuntimeIdentifier);
+        }
+
+#if NETCOREAPP
+        private static string RuntimeIdentifier => RuntimeInformation.RuntimeIdentifier;
+#else
+        private static string RuntimeIdentifier => "unknown";
+#endif
+    }
+}
+

--- a/Prometheus/IMetricFactory.cs
+++ b/Prometheus/IMetricFactory.cs
@@ -25,6 +25,7 @@ public interface IMetricFactory
     Gauge CreateGauge(string name, string help, string[] labelNames, GaugeConfiguration? configuration = null);
     Histogram CreateHistogram(string name, string help, string[] labelNames, HistogramConfiguration? configuration = null);
     Summary CreateSummary(string name, string help, string[] labelNames, SummaryConfiguration? configuration = null);
+    Info CreateInfo(string name, string help, string[] labelNames, InfoConfiguration? configuration = null);
 
     /// <summary>
     /// Returns a new metric factory that will add the specified labels to any metrics created using it.

--- a/Prometheus/Info.cs
+++ b/Prometheus/Info.cs
@@ -1,0 +1,42 @@
+﻿namespace Prometheus;
+
+/// <summary>
+/// Info metrics are used to expose textual information which should not change during process lifetime. The value of an Info metric is always 1.
+/// </summary>
+public sealed class Info : Collector<Info.Child>
+{
+    internal Info(string name, string help, StringSequence instanceLabelNames, LabelSequence staticLabels, bool suppressInitialValue, ExemplarBehavior exemplarBehavior)
+        : base(name, help, instanceLabelNames, staticLabels, suppressInitialValue, exemplarBehavior)
+    {
+
+    }
+
+    internal override MetricType Type => MetricType.Info;
+
+    internal override int TimeseriesCount => 0;
+
+    private protected override Child NewChild(LabelSequence instanceLabels, LabelSequence flattenedLabels, bool publish, ExemplarBehavior exemplarBehavior)
+    {
+        return new Child(this, instanceLabels, flattenedLabels, publish, exemplarBehavior);
+    }
+
+    public sealed class Child : ChildBase
+    {
+        internal Child(Collector parent, LabelSequence instanceLabels, LabelSequence flattenedLabels, bool publish, ExemplarBehavior exemplarBehavior)
+            : base(parent, instanceLabels, flattenedLabels, publish, exemplarBehavior)
+        {
+        }
+
+        private protected override async ValueTask CollectAndSerializeImplAsync(IMetricsSerializer serializer, CancellationToken cancel)
+        {
+            await serializer.WriteMetricPointAsync(
+                Parent.NameBytes,
+                FlattenedLabelsBytes,
+                CanonicalLabel.Empty,
+                1,
+                ObservedExemplar.Empty,
+                null,
+                cancel);
+        }
+    }
+}

--- a/Prometheus/InfoConfiguration.cs
+++ b/Prometheus/InfoConfiguration.cs
@@ -1,0 +1,6 @@
+﻿namespace Prometheus;
+
+public class InfoConfiguration : MetricConfiguration
+{
+    internal static readonly InfoConfiguration Default = new InfoConfiguration();
+}

--- a/Prometheus/InfoConfiguration.cs
+++ b/Prometheus/InfoConfiguration.cs
@@ -3,4 +3,9 @@
 public class InfoConfiguration : MetricConfiguration
 {
     internal static readonly InfoConfiguration Default = new InfoConfiguration();
+
+    /// <summary>
+    /// Includes <see cref="CollectorRegistry.StaticLabels"/> in the info metric. 
+    /// </summary>
+    public bool UseStaticLabels { get; set; } = false;
 }

--- a/Prometheus/MetricFactory.cs
+++ b/Prometheus/MetricFactory.cs
@@ -62,6 +62,12 @@ public sealed class MetricFactory : IMetricFactory
         => CreateHistogram(name, help, configuration?.LabelNames ?? Array.Empty<string>(), configuration);
 
     /// <summary>
+    /// Info metrics are used to expose textual information which should not change during process lifetime. The value of an Info metric is always 1.
+    /// </summary>
+    public Info CreateInfo(string name, string help, InfoConfiguration? configuration = null)
+        => CreateInfo(name, help, configuration?.LabelNames ?? Array.Empty<string>(), configuration);
+
+    /// <summary>
     /// Counters only increase in value and reset to zero when the process restarts.
     /// </summary>
     public Counter CreateCounter(string name, string help, string[] labelNames, CounterConfiguration? configuration = null)
@@ -118,7 +124,7 @@ public sealed class MetricFactory : IMetricFactory
         // Note: exemplars are not supported for info. We just pass it along here to avoid forked APIs downstream.
         var exemplarBehavior = ExemplarBehavior ?? ExemplarBehavior.Default;
 
-        return _registry.GetOrAdd(name, help, instanceLabelNames, _staticLabelsLazy.Value, configuration ?? InfoConfiguration.Default, exemplarBehavior, _createInfoInstanceFunc);
+        return _registry.GetOrAdd(name, help, instanceLabelNames, (configuration?.UseStaticLabels ?? false) ? _staticLabelsLazy.Value : LabelSequence.Empty, configuration ?? InfoConfiguration.Default, exemplarBehavior, _createInfoInstanceFunc);
     }
 
     internal Summary CreateSummary(string name, string help, StringSequence instanceLabelNames, SummaryConfiguration? configuration)

--- a/Prometheus/MetricType.cs
+++ b/Prometheus/MetricType.cs
@@ -5,5 +5,6 @@ internal enum MetricType
     Counter,
     Gauge,
     Summary,
-    Histogram
+    Histogram,
+    Info
 }

--- a/Prometheus/Metrics.cs
+++ b/Prometheus/Metrics.cs
@@ -117,6 +117,12 @@ public static class Metrics
     public static Histogram CreateHistogram(string name, string help, params string[] labelNames) =>
         DefaultFactory.CreateHistogram(name, help, labelNames);
 
+    /// <summary>
+    /// Info metrics are used to expose textual information which should not change during process lifetime. The value of an Info metric is always 1.
+    /// </summary>
+    public static Info CreateInfo(string name, string help, params string[] labelNames) =>
+        DefaultFactory.CreateInfo(name, help, labelNames);
+
     static Metrics()
     {
         DefaultRegistry = new CollectorRegistry();

--- a/Prometheus/SuppressDefaultMetricOptions.cs
+++ b/Prometheus/SuppressDefaultMetricOptions.cs
@@ -6,6 +6,7 @@ public sealed class SuppressDefaultMetricOptions
     {
         SuppressProcessMetrics = true,
         SuppressDebugMetrics = true,
+        SuppressRuntimeInfoMetrics = true,
 #if NET
         SuppressEventCounters = true,
 #endif
@@ -19,6 +20,7 @@ public sealed class SuppressDefaultMetricOptions
     {
         SuppressProcessMetrics = false,
         SuppressDebugMetrics = false,
+        SuppressRuntimeInfoMetrics = false,
 #if NET
         SuppressEventCounters = false,
 #endif
@@ -37,6 +39,11 @@ public sealed class SuppressDefaultMetricOptions
     /// Suppress metrics that prometheus-net uses to report debug information about itself (e.g. number of metrics exported).
     /// </summary>
     public bool SuppressDebugMetrics { get; set; }
+
+    /// <summary>
+    /// Suppress info metrics about runtime.
+    /// </summary>
+    public bool SuppressRuntimeInfoMetrics { get; set; }
 
 #if NET
     /// <summary>
@@ -73,6 +80,9 @@ public sealed class SuppressDefaultMetricOptions
 
         if (!SuppressDebugMetrics)
             Metrics.DefaultRegistry.StartCollectingRegistryMetrics();
+
+        if (!SuppressRuntimeInfoMetrics)
+            DotNetRuntimeInfos.RegisterDefault();
 
 #if NET
         if (!SuppressEventCounters)

--- a/Prometheus/TextSerializer.Net.cs
+++ b/Prometheus/TextSerializer.Net.cs
@@ -43,6 +43,7 @@ internal sealed class TextSerializer : IMetricsSerializer
         { MetricType.Counter, "counter"u8.ToArray() },
         { MetricType.Histogram, "histogram"u8.ToArray() },
         { MetricType.Summary, "summary"u8.ToArray() },
+        { MetricType.Info, "info"u8.ToArray() },
     };
 
     private static readonly char[] DotEChar = ['.', 'e'];

--- a/Prometheus/TextSerializer.NetStandardFx.cs
+++ b/Prometheus/TextSerializer.NetStandardFx.cs
@@ -39,6 +39,7 @@ internal sealed class TextSerializer : IMetricsSerializer
         { MetricType.Counter, "counter"u8.ToArray() },
         { MetricType.Histogram, "histogram"u8.ToArray() },
         { MetricType.Summary, "summary"u8.ToArray() },
+        { MetricType.Info, "info"u8.ToArray() },
     };
 
     private static readonly char[] DotEChar = ['.', 'e'];

--- a/Tests.NetCore/InfoTests.cs
+++ b/Tests.NetCore/InfoTests.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Prometheus.Tests
+{
+    [TestClass]
+    public sealed class InfoTests
+    {
+        [TestMethod]
+        public void CreateInfo_Labels()
+        {
+            var registry = Metrics.NewCustomRegistry();
+            registry.SetStaticLabels(new Dictionary<string, string>() { { "static1", "staticvalue" } });
+            var factory = Metrics.WithCustomRegistry(registry);
+
+            var info = factory.CreateInfo("name", "help", new[] { "label1", "label2" }, new InfoConfiguration() { LabelNames = new[] { "ignored" } });
+            Assert.IsNotNull(info);
+            CollectionAssert.AreEqual(new[] { "label1", "label2" }, info.FlattenedLabelNames.ToArray());
+        }
+
+        [TestMethod]
+        public void CreateInfo_LabelsAndConfiguration()
+        {
+            var registry = Metrics.NewCustomRegistry();
+            registry.SetStaticLabels(new Dictionary<string, string>() { { "static1", "staticvalue" } });
+            var factory = Metrics.WithCustomRegistry(registry);
+
+            var info = factory.CreateInfo("name", "help", new[] { "label1", "label2" }, new InfoConfiguration() { LabelNames = new[] { "ignored" } });
+            Assert.IsNotNull(info);
+            CollectionAssert.AreEqual(new[] { "label1", "label2" }, info.FlattenedLabelNames.ToArray());
+        }
+
+        [TestMethod]
+        public void CreateInfo_LabelsAndConfiguration_UseStaticLabels()
+        {
+            var registry = Metrics.NewCustomRegistry();
+            registry.SetStaticLabels(new Dictionary<string, string>() { { "static1", "staticvalue" } });
+            var factory = Metrics.WithCustomRegistry(registry);
+
+            var info = factory.CreateInfo("name", "help", new[] { "label1", "label2" }, new InfoConfiguration() { LabelNames = new[] { "ignored" }, UseStaticLabels = true });
+            Assert.IsNotNull(info);
+            CollectionAssert.AreEqual(new[] { "label1", "label2", "static1" }, info.FlattenedLabelNames.ToArray());
+        }
+
+        [TestMethod]
+        public void CreateInfo_Configuration()
+        {
+            var registry = Metrics.NewCustomRegistry();
+            registry.SetStaticLabels(new Dictionary<string, string>() { { "static1", "staticvalue" } });
+            var factory = Metrics.WithCustomRegistry(registry);
+
+            var info = factory.CreateInfo("name", "help", new InfoConfiguration() { LabelNames = new[] { "label1", "label2" } });
+            Assert.IsNotNull(info);
+            CollectionAssert.AreEqual(new[] { "label1", "label2" }, info.FlattenedLabelNames.ToArray());
+        }
+
+        [TestMethod]
+        public void CreateInfo_Configuration_UseStaticLabels()
+        {
+            var registry = Metrics.NewCustomRegistry();
+            registry.SetStaticLabels(new Dictionary<string, string>() { { "static1", "staticvalue" } });
+            var factory = Metrics.WithCustomRegistry(registry);
+
+            var info = factory.CreateInfo("name", "help", new InfoConfiguration() { LabelNames = new[] { "label1", "label2" }, UseStaticLabels = true });
+            Assert.IsNotNull(info);
+            CollectionAssert.AreEqual(new[] { "label1", "label2", "static1" }, info.FlattenedLabelNames.ToArray());
+        }
+
+        [TestMethod]
+        public void CreateChild()
+        {
+            var registry = Metrics.NewCustomRegistry();
+            var factory = Metrics.WithCustomRegistry(registry);
+
+            var info = factory.CreateInfo("name", "help", new InfoConfiguration() { LabelNames = new[] { "label1", "label2" }, UseStaticLabels = true });
+            var child = info.WithLabels("value1", "value2");
+
+            Assert.IsNotNull(child);
+            CollectionAssert.AreEqual(new[] { "label1", "label2" }, child.FlattenedLabels.Names.ToArray());
+            CollectionAssert.AreEqual(new[] { "value1", "value2" }, child.FlattenedLabels.Values.ToArray());
+        }
+    }
+}

--- a/Tests.NetCore/TextSerializerTests.cs
+++ b/Tests.NetCore/TextSerializerTests.cs
@@ -272,6 +272,45 @@ boom_bam_total{blah=""foo""} 1.0 # {traceID=""1234"",yaay=""4321""} 1.0 16687799
 ");
     }
 
+    [TestMethod]
+    public async Task ValidateTextFmtInfo()
+    {
+        var result = await TestCase.Run(factory =>
+        {
+            var counter = factory.CreateInfo("boom_bam", "", new InfoConfiguration
+            {
+                LabelNames = new[] { "blah" }
+            });
+
+            counter.WithLabels("foo");
+        });
+
+        result.ShouldBe("# HELP boom_bam \n" +
+                        "# TYPE boom_bam info\n" +
+                        "boom_bam{blah=\"foo\"} 1\n");
+    }
+
+    [TestMethod]
+    public async Task ValidateOpenMetricsFmtInfo()
+    {
+        var result = await TestCase.RunOpenMetrics(factory =>
+        {
+            var counter = factory.CreateInfo("boom_bam", "something", new InfoConfiguration
+            {
+                LabelNames = new[] { "blah" }
+            });
+
+            counter.WithLabels("foo");
+        });
+
+        // This asserts that the le label has been modified and that we have a EOF
+        result.ShouldBe(@"# HELP boom_bam something
+# TYPE boom_bam info
+boom_bam{blah=""foo""} 1
+# EOF
+");
+    }
+
     private const double TestNow = 1668779954.714;
 
     private class TestCase

--- a/Tests.NetFramework/Tests.NetFramework.csproj
+++ b/Tests.NetFramework/Tests.NetFramework.csproj
@@ -88,6 +88,9 @@
     <Compile Include="..\Tests.NetCore\GaugeExtensionTests.cs">
       <Link>GaugeExtensionTests.cs</Link>
     </Compile>
+    <Compile Include="..\Tests.NetCore\InfoTests.cs">
+      <Link>InfoTests.cs</Link>
+    </Compile>
     <Compile Include="..\Tests.NetCore\GaugeTests.cs">
       <Link>GaugeTests.cs</Link>
     </Compile>


### PR DESCRIPTION
Adds Info Metric:
https://github.com/prometheus/OpenMetrics/blob/main/specification/OpenMetrics.md#info
> Info metrics are used to expose textual information which SHOULD NOT change during process lifetime. Common examples are an application's version, revision control commit, and the version of a compiler.
> A MetricPoint of an Info Metric contains a LabelSet. An Info MetricPoint's LabelSet MUST NOT have a label name which is the same as the name of a label of the LabelSet of its Metric.
> Info MAY be used to encode ENUMs whose values do not change over time, such as the type of a network interface.
> MetricFamilies of type Info MUST have an empty Unit string.

According to Java library:
> Info metrics are used to expose textual information which should not change during process lifetime. The value of an Info metric is always 1.

Usage:
```
Metrics
  .CreateInfo("application_info", "Application Version", new[] { "version", "commit" })
  .WithLabels("1.2.3", "60e9106a83ff1274fec0022c37366f04822b1d1b");

```

Also adds a default Info Metric for dotnet runtime informations:
```
# HELP dotnet_info .NET runtime
# TYPE dotnet_info info
dotnet_info{version="6.0.36",framework=".NET 6.0.36",runtime="win10-x64"} 1
```
Can be disabled with `Metrics.SuppressDefaultMetrics(new SuppressDefaultMetricOptions() { SuppressRuntimeInfoMetrics = true } );`.